### PR TITLE
Reference endpoints by address, not number.

### DIFF
--- a/examples/LibusbTest.cpp
+++ b/examples/LibusbTest.cpp
@@ -239,15 +239,15 @@ int main(int argc, char* argv[])
 						std::wcout << L"\t\tInterface descriptor:" << pInterface->DescriptorString() << std::endl;
 						std::wcout << L"\t\tInterface Number of endpoints: " << std::dec << pInterface->NumEndpoints() << std::endl << std::endl;
 
-						// Iterate over the interface endpoints (other than ep0!!) - by the index to number map
-						LibUSB::Interface::EndpointNumbers_t mEndpointNumbers = pInterface->getEndpointNumbers();
-						for (const auto &epnum : mEndpointNumbers)
+						// Iterate over the interface endpoints (other than ep0!!) - by the index to address map
+						LibUSB::Interface::EndpointAddresses_t mEndpointAddresses= pInterface->getEndpointAddresses();
+						for (const auto &epaddr : mEndpointAddresses)
 						{
 
-							std::shared_ptr<LibUSB::Endpoint> pEndpoint = pInterface->getEndpoint(epnum.second);
+							std::shared_ptr<LibUSB::Endpoint> pEndpoint = pInterface->getEndpoint(epaddr.second);
 
 							/// Endpoint information
-							std::wcout << L"\t\t\tEndpoint number: " << std::dec << pEndpoint->Number() << std::endl;
+							std::wcout << L"\t\t\tEndpoint address: " << std::dec << pEndpoint->Address() << std::endl;
 							std::wcout << L"\t\t\tMaxPacketSize: " << std::dec << pEndpoint->MaxPacketSize() << std::endl;
 							std::wcout << L"\t\t\tPolling Interval: " << std::dec << pEndpoint->PollingInterval() << std::endl;
 							std::wcout << L"\t\t\tTransfer Type: ";

--- a/headers/libusbpp/Interface.hpp
+++ b/headers/libusbpp/Interface.hpp
@@ -79,17 +79,17 @@ namespace LibUSB
 		/// Returns the number of endpoints this interface has.
 		int NumEndpoints()const;
 
-		/// Returns the number of a specified endpoint
-		int getEPNumberByIndex(int index)const;
+		/// Returns the address of a specified endpoint
+		int getEPAddressByIndex(int index)const;
 
-		/// Endpoint number container type (index -> number)
-		typedef std::map<int, int> EndpointNumbers_t;
+		/// Endpoint address container type (index -> address)
+		typedef std::map<int, int> EndpointAddresses_t;
 
 		/// Returns the number container of all endpoint indices
-		EndpointNumbers_t getEndpointNumbers()const;
+		EndpointAddresses_t getEndpointAddresses()const;
 
 		/// Returns the specified endpoint
-		std::shared_ptr<Endpoint> getEndpoint(int number);
+		std::shared_ptr<Endpoint> getEndpoint(int address);
 
 	protected:
 	private:

--- a/src/Interface.cpp
+++ b/src/Interface.cpp
@@ -103,27 +103,27 @@ int LibUSB::Interface::NumEndpoints() const
 	return m_pInterfaceImpl->NumEndpoints();
 }
 
-int LibUSB::Interface::getEPNumberByIndex( int index ) const
+int LibUSB::Interface::getEPAddressByIndex( int index ) const
 {
-	return m_pInterfaceImpl->getEPNumberByIndex(index);
+	return m_pInterfaceImpl->getEPAddressByIndex(index);
 }
 
-LibUSB::Interface::EndpointNumbers_t LibUSB::Interface::getEndpointNumbers() const
+LibUSB::Interface::EndpointAddresses_t LibUSB::Interface::getEndpointAddresses() const
 {
-	EndpointNumbers_t mEndpointNumbers;
+	EndpointAddresses_t mEndpointAddresses;
 
 	// Create each endpoint number
 	for (int i = 1; i <= NumEndpoints(); i++)
 	{
-		mEndpointNumbers.insert(std::make_pair(i,getEPNumberByIndex(i)));
+		mEndpointAddresses.insert(std::make_pair(i,getEPAddressByIndex(i)));
 	}
 
-	return mEndpointNumbers;
+	return mEndpointAddresses;
 }
 
-std::shared_ptr<LibUSB::Endpoint> LibUSB::Interface::getEndpoint( int number )
+std::shared_ptr<LibUSB::Endpoint> LibUSB::Interface::getEndpoint( int address )
 {
-	return m_pInterfaceImpl->getEndpoint(number);
+	return m_pInterfaceImpl->getEndpoint(address);
 }
 
 bool LibUSB::Interface::isClaimed() const

--- a/src/InterfaceImpl.cpp
+++ b/src/InterfaceImpl.cpp
@@ -280,18 +280,18 @@ uint8_t LibUSB::InterfaceImpl::NumEndpoints() const
 	return m_pInterface->altsetting[m_alternateSetting].bNumEndpoints;
 }
 
-uint8_t LibUSB::InterfaceImpl::getEPNumberByIndex( uint8_t index ) const
+uint8_t LibUSB::InterfaceImpl::getEPAddressByIndex( uint8_t index ) const
 {
 	if (index == 0)
 	{
-		// Return the number zero of the device control endpoint.
+		// Return the address zero of the device control endpoint.
 		return index;
 	}
 
 
 	if (index > NumEndpoints())
 	{
-		throw std::logic_error("LibUSB::InterfaceImpl::getEPNumberByIndex(): Index out of range.");
+		throw std::logic_error("LibUSB::InterfaceImpl::getEPAddressByIndex(): Index out of range.");
 	}
 
 
@@ -308,22 +308,22 @@ uint8_t LibUSB::InterfaceImpl::getEPNumberByIndex( uint8_t index ) const
 		/// \note #2 Validate endpoint number.
 		if (!pEndpoint->Number())
 		{
-			throw std::logic_error("LibUSB::InterfaceImpl::getEPNumberByIndex(): Endpoint has no number as expected! (note #2)");
+			throw std::logic_error("LibUSB::InterfaceImpl::getEPAddressByIndex(): Endpoint has no number as expected! (note #2)");
 		}
 
 	}
 	else
 	{
-		throw std::logic_error("LibUSB::InterfaceImpl::getEPNumberByIndex(): Endpoint not found.");
+		throw std::logic_error("LibUSB::InterfaceImpl::getEPAddressByIndex(): Endpoint not found.");
 	}
 
 
-	return pEndpoint->Number();
+	return pEndpoint->Address();
 }
 
-std::shared_ptr<LibUSB::Endpoint> LibUSB::InterfaceImpl::getEndpoint( uint8_t number )
+std::shared_ptr<LibUSB::Endpoint> LibUSB::InterfaceImpl::getEndpoint( uint8_t address )
 {
-	if (number == 0)
+	if (address == 0)
 	{
 
 		// Return the device control endpoint zero.
@@ -339,19 +339,19 @@ std::shared_ptr<LibUSB::Endpoint> LibUSB::InterfaceImpl::getEndpoint( uint8_t nu
 
 
 	// Find the endpoint
-	EndpointContainer_t::iterator itEndpoint = m_EndpointContainer.find(number);
+	EndpointContainer_t::iterator itEndpoint = m_EndpointContainer.find(address);
 
 	std::shared_ptr<LibUSB::Endpoint> pEndpoint;
 
 	if (itEndpoint != m_EndpointContainer.end())
 	{
 
-		pEndpoint = m_EndpointContainer.find(number)->second;
+		pEndpoint = m_EndpointContainer.find(address)->second;
 
-		/// \note #1 Validate endpoint number against its number.
-		if (pEndpoint->Number() != number)
+		/// \note #1 Validate endpoint address against its address.
+		if (pEndpoint->Address() != address)
 		{
-			throw std::logic_error("LibUSB::InterfaceImpl::getEndpoint(): Endpoint and number do not match as expected! (note #1)");
+			throw std::logic_error("LibUSB::InterfaceImpl::getEndpoint(): Endpoint and address do not match as expected! (note #1)");
 		}
 
 	}
@@ -421,7 +421,7 @@ void LibUSB::InterfaceImpl::CreateEndpoints()
 			std::shared_ptr<Endpoint> pEndpoint = std::make_shared<Endpoint>(pEPImpl);
 
 			// Store it
-			m_EndpointContainer.insert(std::make_pair(pEndpoint->Number(), pEndpoint));
+			m_EndpointContainer.insert(std::make_pair(pEndpoint->Address(), pEndpoint));
 
 		}
 

--- a/src/InterfaceImpl.hpp
+++ b/src/InterfaceImpl.hpp
@@ -87,11 +87,11 @@ namespace LibUSB
 		/// Returns the number of endpoints this interface/altsetting has.
 		uint8_t NumEndpoints()const;
 
-		/// Returns the number of a specified endpoint
-		uint8_t getEPNumberByIndex(uint8_t index)const;
+		/// Returns the address of a specified endpoint
+		uint8_t getEPAddressByIndex(uint8_t index)const;
 
 		/// Returns the specified endpoint
-		std::shared_ptr<Endpoint> getEndpoint(uint8_t number);
+		std::shared_ptr<Endpoint> getEndpoint(uint8_t address);
 
 	protected:
 


### PR DESCRIPTION
An endpoint address is made up of two nibbles. The upper nibble specifies
the endpoint direction, and the lower nibble is the endpoint number.

libusbpp currently treats endpoint numbers as unique, which is
problematic in the case of a bidirectional endpoint (eg addresses 0x04
and 0x84.)

Change the API to reference endpoints by address, not number.